### PR TITLE
restartServer-method fixed

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,12 +126,13 @@ class Robot {
   _createRequest (method, uri, data) {
 
     data = data || undefined;
+    var contentType = method=="POST"?"application/x-www-form-urlencoded":"application/json";
 
     return new Promise((resolve, reject) => {
       this._apiClient[ method ](
         this.config.baseUrl + uri,
         {
-          headers: { "Content-Type": "application/json" },
+          headers: { "Content-Type": contentType },
           data:    data
         },
         (response, rawData) => this._parseResponse(response, rawData.statusCode, resolve, reject)

--- a/index.js
+++ b/index.js
@@ -740,9 +740,7 @@ class Robot {
 
     resetType = resetType || 'sw';
 
-    var data = {
-      type: resetType
-    };
+    var data = "type="+resetType;
 
     return this._createRequest('post', '/reset/' + ipAddress, data);
   }

--- a/index.js
+++ b/index.js
@@ -126,7 +126,7 @@ class Robot {
   _createRequest (method, uri, data) {
 
     data = data || undefined;
-    var contentType = method=="POST"?"application/x-www-form-urlencoded":"application/json";
+    var contentType = method.toLowerCase()=="post"?"application/x-www-form-urlencoded":"application/json";
 
     return new Promise((resolve, reject) => {
       this._apiClient[ method ](


### PR DESCRIPTION
I've had troubles using the restartServer-method. In their docs, they state:

> "POST-Parameter werden im Format "application/x-www-form-urlencoded" übergeben"

possibly other methods as updateSSHKeyName are affected too. maybe the tests could respect this behaviour also.